### PR TITLE
Move note to the left on expanded TOC

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,8 +1,7 @@
 .noteclassic, .noteimportant, .notewarning, .notetip {
   margin: 2em auto;
-  width: 70% !important;
+  max-width: 70%;
   min-height: 40px;
-  clear: both;
   text-align: justify;
   vertical-align: middle;
   border-collapse: collapse;
@@ -13,6 +12,7 @@
   -khtml-border-radius: 20px;
   border-radius: 20px;
   color: black;
+  overflow: hidden;
 }
  
 .noteclassic {


### PR DESCRIPTION
Adjusted CSS code to let the note move to the left if the TOC is expanded. Fixes #12.