### PR TITLE
Add stylesheet for printing

### DIFF
--- a/print.css
+++ b/print.css
@@ -1,0 +1,44 @@
+.plugin_note {
+  margin: 2em 0;
+  max-width: 100%;
+  min-height: 40px;
+  text-align: justify;
+  vertical-align: middle;
+  border-collapse: collapse;
+  padding: 5px 20px 5px 80px;
+  background-position: 20px 50%;
+  background-repeat: no-repeat;
+  -moz-border-radius: 20px;
+  -khtml-border-radius: 20px;
+  border-radius: 20px;
+  color: black;
+  overflow: hidden;
+}
+
+.plugin_note .li {
+  color: black !important;
+}
+ 
+.noteclassic {
+  border: 1px solid #99D;
+  background-color: #eeeeff;
+  background-image: url(images/note.png);
+}
+ 
+.noteimportant {
+  border: 1px solid #ff0;
+  background-color: #ffffcc;
+  background-image: url(images/important.png);
+}
+ 
+.notewarning {
+  border: 1px solid #d99;
+  background-color: #ffdddd;
+  background-image: url(images/warning.png);
+}
+ 
+.notetip {
+  border: 1px solid #9d9;
+  background-color: #ddffdd;
+  background-image: url(images/tip.png);
+}


### PR DESCRIPTION
Hi,

I basically copied `style.css` to `print.css` to make the note blocks visible on printouts. Only changes: lowered margin (left/right) to from 2em to 0 and padding (top/bottom) from 15px to 5px to save some space on paper. I also re-enabled the slightly darker borders which make the note boxes more distinguishable from the rest of the text, at least on my monochrome printer.